### PR TITLE
fix: Secure Storage SOT issue

### DIFF
--- a/lib/core/common/store/secure_storage_cached_source.dart
+++ b/lib/core/common/store/secure_storage_cached_source.dart
@@ -19,7 +19,7 @@ class SecuredStorageSourceOfTruth extends CachedSourceOfTruth<String, String> {
   @override
   @protected
   Future<void> write(String key, String? value) async {
-    await super.write(key, value);
     await _secureStorage.write(key: key, value: value);
+    await super.write(key, value);
   }
 }


### PR DESCRIPTION

# :wrench: Bugfixes
The write method uses the read method, so we have to write the value in the secure storage before save it in the cache