### PR TITLE
fix: Fix env load issue when the env file doesn't exist

### DIFF
--- a/lib/core/common/config.dart
+++ b/lib/core/common/config.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_template/core/common/environments.dart';
 import 'package:flutter_template/core/common/extension/string_extensions.dart';
 import 'package:flutter_template/core/common/helper/enum_helpers.dart';
@@ -9,6 +10,8 @@ import 'package:flutter_template/core/common/helper/env_helper.dart';
 
 abstract class Config {
   static const String environmentFolder = 'environments';
+
+  static const debugMode = kDebugMode;
 
   static late String apiBaseUrl;
   static late String supabaseApiKey;

--- a/lib/core/common/helper/env_helper.dart
+++ b/lib/core/common/helper/env_helper.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_template/core/common/logger.dart';
 
@@ -12,8 +14,16 @@ Future<Map<String, String>> loadEnvs(
   // ignore: unawaited_futures
   runZonedGuarded(
     () async {
-      await dotEnv.load(fileName: path);
-      completer.complete(dotEnv.env);
+      Map<String, String> envMap = {};
+      // assetExist is called to avoid unnecessary breakpoint exceptions when
+      // the debugger is enabled.
+      // The check is done only in debug to avoid performance issues
+      // https://github.com/java-james/flutter_dotenv/issues/79
+      if (!kDebugMode || await _assetExists(path)) {
+        await dotEnv.load(fileName: path);
+        envMap = dotEnv.env;
+      }
+      completer.complete(envMap);
     },
     (e, s) {
       if (ignoreErrors) {
@@ -25,4 +35,13 @@ Future<Map<String, String>> loadEnvs(
     },
   );
   return completer.future;
+}
+
+Future<bool> _assetExists(String assetPath) async {
+  try {
+    final data = await rootBundle.load(assetPath);
+    return data.lengthInBytes > 0;
+  } catch (e) {
+    return false;
+  }
 }


### PR DESCRIPTION

# :wrench: Bugfixes

#### :pencil2: Description:

Right now if the env file doesn't exist the dot.env package throws an error, so if you are debugging the app, a breakpoint is called. However, sometimes we want to load optional env files. This PR adds a check to avoid these issues.

I've also opened an issue in the [dot env package](https://github.com/java-james/flutter_dotenv/issues/79) to fix this issue in their side.