### PR TITLE
chore: refactor hive base

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,3 @@
 {
-  "flutter": "3.22.1",
-  "flavors": {}
+  "flutter": "3.22.1"
 }

--- a/lib/core/source/common/hive_base_source.dart
+++ b/lib/core/source/common/hive_base_source.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:dartx/dartx.dart';
 import 'package:flutter_template/core/source/common/local_storage.dart';

--- a/lib/core/source/common/hive_base_source.dart
+++ b/lib/core/source/common/hive_base_source.dart
@@ -8,8 +8,8 @@ import 'package:mutex/mutex.dart';
 import 'package:rxdart/rxdart.dart';
 
 abstract class HiveBaseSource<Key, Model> implements LocalStorage<Key, Model> {
-  final Map<String, dynamic> Function(Model) dbParser;
-  final Model Function(Map<String, dynamic>) modelParser;
+  final String Function(Model) dbParser;
+  final Model Function(String) modelParser;
   final Mutex _mutex = Mutex();
   Box<String>? _box;
 
@@ -35,7 +35,7 @@ abstract class HiveBaseSource<Key, Model> implements LocalStorage<Key, Model> {
       withBox((box) async {
         await box.put(
           key,
-          jsonEncode(dbParser(response)),
+          dbParser(response),
         );
         return response;
       });
@@ -45,7 +45,7 @@ abstract class HiveBaseSource<Key, Model> implements LocalStorage<Key, Model> {
       withBox((box) async {
         await box.putAll(
           entries.mapValues(
-            (entry) => jsonEncode(dbParser(entry.value)),
+            (entry) => dbParser(entry.value),
           ),
         );
         return getElements();
@@ -63,7 +63,7 @@ abstract class HiveBaseSource<Key, Model> implements LocalStorage<Key, Model> {
   ) =>
       withBox((box) async {
         final data = box.get(key);
-        return data == null ? null : modelParser(jsonDecode(data));
+        return data == null ? null : modelParser(data);
       });
 
   @override
@@ -73,14 +73,14 @@ abstract class HiveBaseSource<Key, Model> implements LocalStorage<Key, Model> {
     final box = await getBox();
     yield await getElement(key);
     yield* box.watch(key: key).map(
-          (event) => modelParser(jsonDecode(event.value)),
+          (event) => modelParser(event.value),
         );
   }
 
   @override
   Future<List<Model>> getElements() => withBox(
         (box) => Future.value(
-          box.values.map((e) => modelParser(jsonDecode(e))).toList(),
+          box.values.map((e) => modelParser(e)).toList(),
         ),
       );
 

--- a/lib/core/source/project_local_source.dart
+++ b/lib/core/source/project_local_source.dart
@@ -1,11 +1,13 @@
+import 'dart:convert';
+
 import 'package:flutter_template/core/model/project.dart';
 import 'package:flutter_template/core/source/common/hive_base_source.dart';
 
 class ProjectLocalSource extends HiveBaseSource<int, Project> {
   ProjectLocalSource()
       : super(
-          dbParser: (project) => project.toJson(),
-          modelParser: (project) => Project.fromJson(project),
+          dbParser: (project) => jsonEncode(project.toJson()),
+          modelParser: (project) => Project.fromJson(jsonDecode(project)),
         );
 
   Future<List<Project>> replaceProjects(List<Project> elements) async {


### PR DESCRIPTION
# :recycle: Refactor

#### :pencil2: Description:
Refactor hive base: We were restricting the model to be a JSON object. With this change, it doesn't matter what the JSON type is; an object or list can now be stored.